### PR TITLE
Replace Home feed pagination with infinite scroll

### DIFF
--- a/app/assets/stylesheets/posts.scss
+++ b/app/assets/stylesheets/posts.scss
@@ -210,6 +210,39 @@
     }
   }
 
+  .feed-sentinel {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 24px 0;
+    color: #8e8e8e;
+    font-size: 14px;
+
+    &__end {
+      margin: 0;
+    }
+
+    &__loader {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    &__spinner i {
+      font-size: 20px;
+    }
+
+    &__link {
+      color: #00376b;
+      font-weight: 600;
+      text-decoration: none;
+
+      &:hover {
+        text-decoration: underline;
+      }
+    }
+  }
+
   .pagination {
     display: flex;
     align-items: center;

--- a/app/assets/stylesheets/posts.scss
+++ b/app/assets/stylesheets/posts.scss
@@ -1,3 +1,13 @@
+%link-accent {
+  color: #00376b;
+  font-weight: 600;
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
 .homepage {
   max-width: 630px;
   margin: 40px auto;
@@ -173,13 +183,7 @@
         color: #262626;
 
         a {
-          color: #00376b;
-          font-weight: 600;
-          text-decoration: none;
-
-          &:hover {
-            text-decoration: underline;
-          }
+          @extend %link-accent;
         }
       }
 
@@ -233,13 +237,7 @@
     }
 
     &__link {
-      color: #00376b;
-      font-weight: 600;
-      text-decoration: none;
-
-      &:hover {
-        text-decoration: underline;
-      }
+      @extend %link-accent;
     }
   }
 
@@ -341,13 +339,7 @@
     color: #262626;
 
     a {
-      color: #00376b;
-      font-weight: 600;
-      text-decoration: none;
-
-      &:hover {
-        text-decoration: underline;
-      }
+      @extend %link-accent;
     }
   }
 

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -4,7 +4,12 @@ class HomeController < ApplicationController
   def index
     @posts          = Post.includes(user: { avatar_attachment: :blob }, image_attachment: :blob)
                           .created_recently
-                          .page(params[:page]).per(10)
+                          .page(params[:page]).per(10).without_count
     @user_reactions = current_user.reactions.where(reactable: @posts).index_by(&:reactable_id)
+
+    respond_to do |format|
+      format.html
+      format.turbo_stream
+    end
   end
 end

--- a/app/javascript/controllers/infinite_scroll_controller.js
+++ b/app/javascript/controllers/infinite_scroll_controller.js
@@ -1,0 +1,40 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["spinner", "link"]
+  static values = { url: String }
+
+  connect() {
+    this.observer = new IntersectionObserver(this.load.bind(this), { rootMargin: "200px" })
+    this.observer.observe(this.element)
+  }
+
+  disconnect() {
+    this.observer?.disconnect()
+  }
+
+  async load(entries) {
+    if (!entries.some((entry) => entry.isIntersecting) || this.loading) return
+
+    this.loading = true
+    this.observer.disconnect()
+    this.spinnerTarget.hidden = false
+    this.linkTarget.hidden = true
+
+    try {
+      const response = await fetch(this.urlValue, {
+        headers: { Accept: "text/vnd.turbo-stream.html" }
+      })
+
+      if (!response.ok) throw new Error(`Failed to load more posts: ${response.status}`)
+
+      Turbo.renderStreamMessage(await response.text())
+    } catch (error) {
+      console.error(error)
+      this.spinnerTarget.hidden = true
+      this.linkTarget.hidden = false
+      this.loading = false
+      this.observer.observe(this.element)
+    }
+  }
+}

--- a/app/javascript/controllers/infinite_scroll_controller.js
+++ b/app/javascript/controllers/infinite_scroll_controller.js
@@ -14,9 +14,8 @@ export default class extends Controller {
   }
 
   async load(entries) {
-    if (!entries.some((entry) => entry.isIntersecting) || this.loading) return
+    if (!entries.some((entry) => entry.isIntersecting)) return
 
-    this.loading = true
     this.observer.disconnect()
     this.spinnerTarget.hidden = false
     this.linkTarget.hidden = true
@@ -33,7 +32,6 @@ export default class extends Controller {
       console.error(error)
       this.spinnerTarget.hidden = true
       this.linkTarget.hidden = false
-      this.loading = false
       this.observer.observe(this.element)
     }
   }

--- a/app/views/home/_feed_sentinel.html.erb
+++ b/app/views/home/_feed_sentinel.html.erb
@@ -1,0 +1,12 @@
+<div id="feed_sentinel" class="feed-sentinel">
+  <% if posts.last_page? %>
+    <p class="feed-sentinel__end">You're all caught up</p>
+  <% else %>
+    <div class="feed-sentinel__loader" data-controller="infinite-scroll" data-infinite-scroll-url-value="<%= root_path(page: posts.next_page) %>">
+      <div class="feed-sentinel__spinner" data-infinite-scroll-target="spinner" hidden>
+        <i class="fa fa-spinner fa-spin"></i>
+      </div>
+      <%= link_to "Load more", root_path(page: posts.next_page), class: "feed-sentinel__link", data: { infinite_scroll_target: "link" } %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/home/_feed_sentinel.html.erb
+++ b/app/views/home/_feed_sentinel.html.erb
@@ -2,11 +2,12 @@
   <% if posts.last_page? %>
     <p class="feed-sentinel__end">You're all caught up</p>
   <% else %>
-    <div class="feed-sentinel__loader" data-controller="infinite-scroll" data-infinite-scroll-url-value="<%= root_path(page: posts.next_page) %>">
+    <% next_page_url = root_path(page: posts.next_page) %>
+    <div class="feed-sentinel__loader" data-controller="infinite-scroll" data-infinite-scroll-url-value="<%= next_page_url %>">
       <div class="feed-sentinel__spinner" data-infinite-scroll-target="spinner" hidden>
         <i class="fa fa-spinner fa-spin"></i>
       </div>
-      <%= link_to "Load more", root_path(page: posts.next_page), class: "feed-sentinel__link", data: { infinite_scroll_target: "link" } %>
+      <%= link_to "Load more", next_page_url, class: "feed-sentinel__link", data: { infinite_scroll_target: "link" } %>
     </div>
   <% end %>
 </div>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -3,17 +3,17 @@
     <%= render 'upload_form' %>
   </div>
 
-  <div class="posts">
-    <% if @posts.load.any? %>
+  <% if @posts.load.any? %>
+    <div class="posts" id="posts">
       <% @posts.each do |post| %>
         <%= render partial: 'post', locals: { post: post, user_reaction: @user_reactions[post.id] } %>
       <% end %>
-      <%= paginate @posts %>
-    <% else %>
-      <div class="empty-state">
-        <i class="fa fa-camera"></i>
-        <p>No posts yet. Share your first photo above.</p>
-      </div>
-    <% end %>
-  </div>
+    </div>
+    <%= render "feed_sentinel", posts: @posts %>
+  <% else %>
+    <div class="empty-state">
+      <i class="fa fa-camera"></i>
+      <p>No posts yet. Share your first photo above.</p>
+    </div>
+  <% end %>
 </div>

--- a/app/views/home/index.turbo_stream.erb
+++ b/app/views/home/index.turbo_stream.erb
@@ -1,0 +1,9 @@
+<%= turbo_stream.append "posts" do %>
+  <% @posts.each do |post| %>
+    <%= render partial: "post", locals: { post: post, user_reaction: @user_reactions[post.id] } %>
+  <% end %>
+<% end %>
+
+<%= turbo_stream.replace "feed_sentinel" do %>
+  <%= render "feed_sentinel", posts: @posts %>
+<% end %>

--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -60,4 +60,33 @@ class HomeControllerTest < ActionDispatch::IntegrationTest
     get root_path(page: 2)
     assert_select "section.post", count: 3
   end
+
+  test "the feed sentinel links to the next page when more posts remain" do
+    sign_in users(:one)
+    11.times { |n| create_post!(users(:one), description: "post #{n}") }
+
+    get root_path
+
+    assert_select "#feed_sentinel a[href=?]", root_path(page: 2)
+  end
+
+  test "the feed sentinel shows an end state on the last page" do
+    sign_in users(:one)
+
+    get root_path
+
+    assert_select "#feed_sentinel a", false
+    assert_select "#feed_sentinel", text: /caught up/i
+  end
+
+  test "requesting a page as turbo stream appends posts and replaces the sentinel" do
+    sign_in users(:one)
+    11.times { |n| create_post!(users(:one), description: "post #{n}") }
+
+    get root_path(page: 2), as: :turbo_stream
+
+    assert_turbo_stream action: "append", target: "posts"
+    assert_turbo_stream action: "replace", target: "feed_sentinel"
+    assert_select "turbo-stream[action=append][target=posts] section.post", count: 3
+  end
 end

--- a/test/system/home_feed_test.rb
+++ b/test/system/home_feed_test.rb
@@ -1,0 +1,21 @@
+require "application_system_test_case"
+
+class HomeFeedTest < ApplicationSystemTestCase
+  setup do
+    11.times { |n| create_post!(users(:one), description: "post #{n}") }
+    sign_in_as users(:one)
+    wait_for_page_to_settle
+  end
+
+  test "scrolling to the bottom of the feed loads the next page without a page reload" do
+    assert_selector "section.post", count: 10
+    assert_no_selector "section.post", text: "post 0"
+
+    execute_script "window.scrollTo(0, document.body.scrollHeight)"
+
+    assert_selector "section.post", count: 13
+    assert_selector "section.post", text: "post 0"
+    assert_selector "#feed_sentinel", text: "caught up"
+    assert_no_selector "#feed_sentinel a"
+  end
+end


### PR DESCRIPTION
## Summary
- Replaces Kaminari pagination links on the home feed with scroll-triggered infinite loading: a Stimulus `IntersectionObserver` fetches the next page as a Turbo Stream and appends posts, showing a spinner while loading and a "You're all caught up" end state.
- A real `<a href>` fallback (`Load more`) keeps the feed usable with JS disabled.
- Uses Kaminari's `.without_count` so scroll-triggered fetches skip the `SELECT COUNT(*)` query that manual pagination used to only run on explicit clicks.
