### PR TITLE
Revamp the Devise auth UI

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,5 +1,6 @@
 @import "bootstrap";
 @import "font-awesome";
+@import "auth";
 @import "users";
 @import "posts";
 @import "comments";

--- a/app/assets/stylesheets/auth.scss
+++ b/app/assets/stylesheets/auth.scss
@@ -1,0 +1,206 @@
+$auth-border: #dbdbdb;
+$auth-text: #262626;
+$auth-muted: #8e8e8e;
+$auth-link: #003569;
+
+.auth-body {
+  background-color: #fafafa;
+}
+
+.auth-page {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 30px;
+  max-width: 1000px;
+  margin: 0 auto;
+  padding: 40px 20px;
+  min-height: 500px;
+}
+
+.auth-showcase {
+  display: none;
+
+  @media (min-width: 992px) {
+    display: block;
+  }
+}
+
+.phone {
+  width: 320px;
+  height: 590px;
+  border: 12px solid $auth-text;
+  border-radius: 40px;
+  background-color: $auth-text;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, .12);
+  overflow: hidden;
+  position: relative;
+
+  &::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 120px;
+    height: 20px;
+    background-color: $auth-text;
+    border-bottom-left-radius: 12px;
+    border-bottom-right-radius: 12px;
+    z-index: 2;
+  }
+}
+
+.phone-screen {
+  width: 100%;
+  height: 100%;
+  border-radius: 28px;
+  overflow: hidden;
+  background-color: #fff;
+
+  img {
+    width: 100%;
+    display: block;
+  }
+}
+
+.auth-panel {
+  width: 100%;
+  max-width: 350px;
+}
+
+.auth-card {
+  background-color: #fff;
+  border: 1px solid $auth-border;
+  border-radius: 1px;
+  padding: 40px 40px 30px;
+  margin-bottom: 10px;
+  text-align: center;
+  color: $auth-text;
+
+  .alert {
+    text-align: left;
+  }
+}
+
+.auth-card-secondary {
+  padding: 20px;
+  font-size: 14px;
+
+  a {
+    color: #0095f6;
+    font-weight: 600;
+    text-decoration: none;
+  }
+}
+
+.auth-logo {
+  font-size: 42px;
+  font-weight: 200;
+  margin-bottom: 25px;
+}
+
+.auth-heading {
+  font-size: 16px;
+  font-weight: 600;
+  margin-bottom: 10px;
+}
+
+.auth-tagline {
+  color: $auth-muted;
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 18px;
+  margin-bottom: 20px;
+}
+
+.auth-lock {
+  width: 96px;
+  height: 96px;
+  margin: 10px auto 20px;
+  border: 2px solid $auth-text;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  i.fa {
+    font-size: 40px;
+  }
+}
+
+.auth-form {
+  .form-control {
+    background-color: #fafafa;
+    border: 1px solid #dbdbdb;
+    border-radius: 3px;
+    font-size: 13px;
+    padding: 9px 8px;
+    margin-bottom: 6px;
+
+    &:focus {
+      border-color: #a8a8a8;
+      box-shadow: none;
+    }
+  }
+}
+
+.auth-submit {
+  width: 100%;
+  background-color: #0095f6;
+  border: none;
+  border-radius: 4px;
+  font-size: 14px;
+  font-weight: 600;
+  padding: 7px 16px;
+  margin-top: 8px;
+
+  &:hover {
+    background-color: #1877f2;
+  }
+}
+
+.auth-remember {
+  display: block;
+  margin-top: 12px;
+  font-size: 13px;
+  color: $auth-muted;
+
+  input {
+    margin-right: 6px;
+  }
+}
+
+.auth-terms {
+  color: $auth-muted;
+  font-size: 12px;
+  line-height: 16px;
+  margin: 12px 0 0;
+}
+
+.auth-divider {
+  display: flex;
+  align-items: center;
+  margin: 18px 0;
+  color: $auth-muted;
+  font-size: 13px;
+  font-weight: 600;
+
+  &::before,
+  &::after {
+    content: "";
+    flex: 1;
+    height: 1px;
+    background-color: $auth-border;
+  }
+
+  span {
+    padding: 0 18px;
+  }
+}
+
+.auth-muted-link {
+  color: $auth-link;
+  font-size: 12px;
+  text-decoration: none;
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,10 +3,16 @@ class ApplicationController < ActionController::Base
 
   layout :layout_by_resource
 
+  before_action :configure_permitted_parameters, if: :devise_controller?
+
   private
 
   def layout_by_resource
     devise_controller? && !user_signed_in? ? "auth" : "application"
+  end
+
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up, keys: %i[name username])
   end
 
   def log_event(event_type:, subject:)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,13 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
+  layout :layout_by_resource
+
   private
+
+  def layout_by_resource
+    devise_controller? && !user_signed_in? ? "auth" : "application"
+  end
 
   def log_event(event_type:, subject:)
     LogEventJob.perform_later(

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,6 +1,13 @@
 # frozen_string_literal: true
 
 module UsersHelper
+  SETTINGS_PLACEHOLDER_TABS = {
+    "Authorized Applications" => "v-pills-apps",
+    "Email and SMS" => "v-pills-contact",
+    "Manage Contacts" => "v-pills-contacts",
+    "Privacy and Security" => "v-pills-privacy"
+  }.freeze
+
   def external_url(url)
     return "" if url.blank?
 

--- a/app/javascript/controllers/tabs_controller.js
+++ b/app/javascript/controllers/tabs_controller.js
@@ -2,18 +2,19 @@ import { Controller } from "@hotwired/stimulus"
 
 // Vanilla replacement for Bootstrap 4's data-toggle="pill" vertical tabs
 // (app/views/users/edit.html.erb). Toggles .active on the clicked tab and
-// its matching .tab-pane by index.
+// the .tab-pane whose id matches the tab's href.
 export default class extends Controller {
   static targets = ["tab", "pane"]
 
   select(event) {
     event.preventDefault()
-    const index = this.tabTargets.indexOf(event.currentTarget)
+    const paneId = event.currentTarget.getAttribute("href").slice(1)
 
-    this.tabTargets.forEach((tab, i) => tab.classList.toggle("active", i === index))
-    this.paneTargets.forEach((pane, i) => {
-      pane.classList.toggle("active", i === index)
-      pane.classList.toggle("show", i === index)
+    this.tabTargets.forEach((tab) => tab.classList.toggle("active", tab === event.currentTarget))
+    this.paneTargets.forEach((pane) => {
+      const isSelected = pane.id === paneId
+      pane.classList.toggle("active", isSelected)
+      pane.classList.toggle("show", isSelected)
     })
   }
 }

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -9,8 +9,10 @@
     <%= render "devise/shared/error_messages", resource: resource %>
     <%= f.hidden_field :reset_password_token %>
 
+    <%= f.label :password, "New Password", class: "visually-hidden" %>
     <%= f.password_field :password, autofocus: true, autocomplete: "new-password",
                          class: "form-control", placeholder: "New Password" %>
+    <%= f.label :password_confirmation, "Confirm New Password", class: "visually-hidden" %>
     <%= f.password_field :password_confirmation, autocomplete: "new-password",
                          class: "form-control", placeholder: "Confirm New Password" %>
 

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,0 +1,23 @@
+<div class="auth-card">
+  <div class="auth-lock"><i class="fa fa-lock"></i></div>
+  <h1 class="auth-heading">Choose a new password</h1>
+  <p class="auth-tagline">
+    Create a new password that's at least <%= @minimum_password_length %> characters long.
+  </p>
+
+  <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put, class: "auth-form" }) do |f| %>
+    <%= render "devise/shared/error_messages", resource: resource %>
+    <%= f.hidden_field :reset_password_token %>
+
+    <%= f.password_field :password, autofocus: true, autocomplete: "new-password",
+                         class: "form-control", placeholder: "New Password" %>
+    <%= f.password_field :password_confirmation, autocomplete: "new-password",
+                         class: "form-control", placeholder: "Confirm New Password" %>
+
+    <%= f.submit "Reset Password", class: "btn btn-primary auth-submit" %>
+  <% end %>
+</div>
+
+<div class="auth-card auth-card-secondary">
+  <%= link_to "Back To Login", new_session_path(resource_name) %>
+</div>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -8,6 +8,7 @@
   <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post, class: "auth-form" }) do |f| %>
     <%= render "devise/shared/error_messages", resource: resource %>
 
+    <%= f.label :email, class: "visually-hidden" %>
     <%= f.email_field :email, autofocus: true, autocomplete: "email",
                       class: "form-control", placeholder: "Email" %>
 

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,0 +1,24 @@
+<div class="auth-card">
+  <div class="auth-lock"><i class="fa fa-lock"></i></div>
+  <h1 class="auth-heading">Trouble logging in?</h1>
+  <p class="auth-tagline">
+    Enter your email and we'll send you a link to get back into your account.
+  </p>
+
+  <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post, class: "auth-form" }) do |f| %>
+    <%= render "devise/shared/error_messages", resource: resource %>
+
+    <%= f.email_field :email, autofocus: true, autocomplete: "email",
+                      class: "form-control", placeholder: "Email" %>
+
+    <%= f.submit "Send Login Link", class: "btn btn-primary auth-submit" %>
+  <% end %>
+
+  <div class="auth-divider"><span>OR</span></div>
+
+  <%= link_to "Create New Account", new_registration_path(resource_name), class: "auth-muted-link" %>
+</div>
+
+<div class="auth-card auth-card-secondary">
+  <%= link_to "Back To Login", new_session_path(resource_name) %>
+</div>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,0 +1,53 @@
+<div class="user-edit-page">
+  <div class="actions">
+    <%= render "users/settings_nav", active: :password %>
+  </div>
+
+  <div class="details">
+    <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put, class: "form-horizontal form-edit-user" }) do |f| %>
+      <%= render "devise/shared/error_messages", resource: resource %>
+
+      <div class="row mb-3">
+        <div class="col-sm-3 col-form-label">
+          <% if current_user.avatar.attached? %>
+            <%= image_tag current_user.avatar.variant(resize_to_fill: [ 76, 76 ]), class: 'avatar' %>
+          <% end %>
+        </div>
+        <div class="col-sm-9">
+          <p class="username"><%= current_user.username %></p>
+        </div>
+      </div>
+
+      <div class="row mb-3">
+        <%= f.label :current_password, "Old Password", class: 'col-sm-3 col-form-label' %>
+        <div class="col-sm-9">
+          <%= f.password_field :current_password, autocomplete: "current-password", class: 'form-control' %>
+        </div>
+      </div>
+
+      <div class="row mb-3">
+        <%= f.label :password, "New Password", class: 'col-sm-3 col-form-label' %>
+        <div class="col-sm-9">
+          <%= f.password_field :password, autocomplete: "new-password", class: 'form-control' %>
+          <small class="form-text text-muted">
+            At least <%= @minimum_password_length %> characters.
+          </small>
+        </div>
+      </div>
+
+      <div class="row mb-3">
+        <%= f.label :password_confirmation, "Confirm New Password", class: 'col-sm-3 col-form-label' %>
+        <div class="col-sm-9">
+          <%= f.password_field :password_confirmation, autocomplete: "new-password", class: 'form-control' %>
+        </div>
+      </div>
+
+      <div class="row mb-3">
+        <div class="col-sm-3"></div>
+        <div class="col-sm-9">
+          <%= f.submit "Change Password", class: 'btn btn-primary' %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -5,14 +5,19 @@
   <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { class: "auth-form" }) do |f| %>
     <%= render "devise/shared/error_messages", resource: resource %>
 
+    <%= f.label :email, class: "visually-hidden" %>
     <%= f.email_field :email, autofocus: true, autocomplete: "email",
                       class: "form-control", placeholder: "Email" %>
+    <%= f.label :name, "Full Name", class: "visually-hidden" %>
     <%= f.text_field :name, autocomplete: "name",
                      class: "form-control", placeholder: "Full Name" %>
+    <%= f.label :username, class: "visually-hidden" %>
     <%= f.text_field :username, autocomplete: "username",
                      class: "form-control", placeholder: "Username" %>
+    <%= f.label :password, class: "visually-hidden" %>
     <%= f.password_field :password, autocomplete: "new-password",
                          class: "form-control", placeholder: "Password" %>
+    <%= f.label :password_confirmation, "Confirm Password", class: "visually-hidden" %>
     <%= f.password_field :password_confirmation, autocomplete: "new-password",
                          class: "form-control", placeholder: "Confirm Password" %>
 

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,0 +1,30 @@
+<div class="auth-card">
+  <h1 class="auth-logo">Instagram</h1>
+  <p class="auth-tagline">Sign up to see photos and videos from your friends.</p>
+
+  <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { class: "auth-form" }) do |f| %>
+    <%= render "devise/shared/error_messages", resource: resource %>
+
+    <%= f.email_field :email, autofocus: true, autocomplete: "email",
+                      class: "form-control", placeholder: "Email" %>
+    <%= f.text_field :name, autocomplete: "name",
+                     class: "form-control", placeholder: "Full Name" %>
+    <%= f.text_field :username, autocomplete: "username",
+                     class: "form-control", placeholder: "Username" %>
+    <%= f.password_field :password, autocomplete: "new-password",
+                         class: "form-control", placeholder: "Password" %>
+    <%= f.password_field :password_confirmation, autocomplete: "new-password",
+                         class: "form-control", placeholder: "Confirm Password" %>
+
+    <p class="auth-terms">
+      By signing up, you agree to our Terms, Data Policy and Cookies Policy.
+    </p>
+
+    <%= f.submit "Sign Up", class: "btn btn-primary auth-submit" %>
+  <% end %>
+</div>
+
+<div class="auth-card auth-card-secondary">
+  Have an account?
+  <%= link_to "Log in", new_session_path(resource_name) %>
+</div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,0 +1,28 @@
+<div class="auth-card">
+  <h1 class="auth-logo">Instagram</h1>
+
+  <%= form_for(resource, as: resource_name, url: session_path(resource_name), html: { class: "auth-form" }) do |f| %>
+    <%= f.email_field :email, autofocus: true, autocomplete: "email",
+                      class: "form-control", placeholder: "Email" %>
+    <%= f.password_field :password, autocomplete: "current-password",
+                         class: "form-control", placeholder: "Password" %>
+
+    <%= f.submit "Log In", class: "btn btn-primary auth-submit" %>
+
+    <% if devise_mapping.rememberable? %>
+      <label class="auth-remember">
+        <%= f.check_box :remember_me %>
+        <%= f.label :remember_me %>
+      </label>
+    <% end %>
+  <% end %>
+
+  <div class="auth-divider"><span>OR</span></div>
+
+  <%= link_to "Forgot password?", new_password_path(resource_name), class: "auth-muted-link" %>
+</div>
+
+<div class="auth-card auth-card-secondary">
+  Don't have an account?
+  <%= link_to "Sign up", new_registration_path(resource_name) %>
+</div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -2,8 +2,10 @@
   <h1 class="auth-logo">Instagram</h1>
 
   <%= form_for(resource, as: resource_name, url: session_path(resource_name), html: { class: "auth-form" }) do |f| %>
+    <%= f.label :email, class: "visually-hidden" %>
     <%= f.email_field :email, autofocus: true, autocomplete: "email",
                       class: "form-control", placeholder: "Email" %>
+    <%= f.label :password, class: "visually-hidden" %>
     <%= f.password_field :password, autocomplete: "current-password",
                          class: "form-control", placeholder: "Password" %>
 

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -7,7 +7,7 @@
     <%= f.password_field :password, autocomplete: "current-password",
                          class: "form-control", placeholder: "Password" %>
 
-    <%= f.submit "Log In", class: "btn btn-primary auth-submit" %>
+    <%= f.submit "Log in", class: "btn btn-primary auth-submit" %>
 
     <% if devise_mapping.rememberable? %>
       <label class="auth-remember">

--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -1,0 +1,15 @@
+<% if resource.errors.any? %>
+  <div id="error_explanation" data-turbo-temporary>
+    <h2>
+      <%= I18n.t("errors.messages.not_saved",
+                 count: resource.errors.count,
+                 resource: resource.class.model_name.human.downcase)
+       %>
+    </h2>
+    <ul>
+      <% resource.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -1,0 +1,19 @@
+<footer class="container footer">
+  <nav class="navbar d-flex">
+    <ul>
+      <li>ABOUT US
+      </li>
+      <li>SUPPORT</li>
+      <li>PRESS</li>
+      <li>API</li>
+      <li>JOBS</li>
+      <li>PRIVACY</li>
+      <li>TERMS</li>
+      <li>DIRECTORY</li>
+      <li>PROFILES</li>
+      <li>HASHTAGS</li>
+      <li>LANGUAGE</li>
+    </ul>
+    <p> © 2018 INSTAGRAM </p>
+  </nav>
+</footer>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -58,25 +58,7 @@
     </main>
 
     <!--Footer-->
-    <footer class="container footer">
-      <nav class="navbar d-flex">
-        <ul>
-          <li>ABOUT US
-          </li>
-          <li>SUPPORT</li>
-          <li>PRESS</li>
-          <li>API</li>
-          <li>JOBS</li>
-          <li>PRIVACY</li>
-          <li>TERMS</li>
-          <li>DIRECTORY</li>
-          <li>PROFILES</li>
-          <li>HASHTAGS</li>
-          <li>LANGUAGE</li>
-        </ul>
-        <p> © 2018 INSTAGRAM </p>
-      </nav>
-    </footer>
+    <%= render "layouts/footer" %>
 
     <%= turbo_frame_tag "post_modal" %>
   </body>

--- a/app/views/layouts/auth.html.erb
+++ b/app/views/layouts/auth.html.erb
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Instagram</title>
+    <%= csrf_meta_tags %>
+    <%= csp_meta_tag %>
+
+    <%= stylesheet_link_tag 'application', media: 'all', 'data-turbo-track': 'reload' %>
+    <%= javascript_importmap_tags %>
+  </head>
+
+  <body class="auth-body">
+    <main class="auth-page">
+      <div class="auth-showcase">
+        <div class="phone">
+          <div class="phone-screen">
+            <%= image_tag "home_page.png", alt: "" %>
+          </div>
+        </div>
+      </div>
+
+      <div class="auth-panel">
+        <% flash.each do |type, message| %>
+          <div class="alert alert-<%= type == "alert" ? "danger" : "success" %>"><%= message %></div>
+        <% end %>
+        <%= yield %>
+      </div>
+    </main>
+
+    <%= render "layouts/footer" %>
+  </body>
+</html>

--- a/app/views/users/_settings_nav.html.erb
+++ b/app/views/users/_settings_nav.html.erb
@@ -1,0 +1,12 @@
+<div class="nav flex-column nav-pills" role="tablist" aria-orientation="vertical">
+  <%= link_to "Edit Profile", edit_user_path(current_user),
+              class: "nav-link #{'active' if active == :profile}" %>
+  <%= link_to "Change Password", edit_user_registration_path,
+              class: "nav-link #{'active' if active == :password}" %>
+  <% local_assigns.fetch(:placeholder_tabs, {}).each do |label, anchor| %>
+    <a class="nav-link" data-tabs-target="tab" data-action="click->tabs#select"
+       href="#<%= anchor %>" role="tab" aria-selected="false"><%= label %></a>
+  <% end %>
+  <%= link_to "Log Out", destroy_user_session_path,
+              data: { turbo_method: :delete }, class: "nav-link" %>
+</div>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,14 +1,7 @@
 <div class="user-edit-page" data-controller="tabs">
   <div class="actions">
-    <div class="nav flex-column nav-pills" role="tablist" aria-orientation="vertical">
-      <a class="nav-link active" data-tabs-target="tab" data-action="click->tabs#select" href="#v-pills-home" role="tab" aria-selected="true">Edit Profile</a>
-      <a class="nav-link" data-tabs-target="tab" data-action="click->tabs#select" href="#v-pills-password" role="tab" aria-selected="false">Change Password</a>
-      <a class="nav-link" data-tabs-target="tab" data-action="click->tabs#select" href="#v-pills-apps" role="tab" aria-selected="false">Authorized Applications</a>
-      <a class="nav-link" data-tabs-target="tab" data-action="click->tabs#select" href="#v-pills-contact" role="tab" aria-selected="false">Email and SMS</a>
-      <a class="nav-link" data-tabs-target="tab" data-action="click->tabs#select" href="#v-pills-contacts" role="tab" aria-selected="false">Manage Contacts</a>
-      <a class="nav-link" data-tabs-target="tab" data-action="click->tabs#select" href="#v-pills-privacy" role="tab" aria-selected="false">Privacy and Security</a>
-      <%= link_to 'Log Out', destroy_user_session_path, data: { turbo_method: :delete }, class: "nav-link" %>
-    </div>
+    <%= render "users/settings_nav", active: :profile,
+                                     placeholder_tabs: UsersHelper::SETTINGS_PLACEHOLDER_TABS %>
   </div>
   <div class="details tab-content">
     <div class="tab-pane fade show active" data-tabs-target="pane" id="v-pills-home" role="tabpanel" aria-labelledby="v-pills-home-tab">
@@ -80,9 +73,6 @@
           </div>
         </div>
       <% end %>
-    </div>
-    <div class="tab-pane fade" data-tabs-target="pane" id="v-pills-password" role="tabpanel">
-      <p>Change Password — coming soon.</p>
     </div>
     <div class="tab-pane fade" data-tabs-target="pane" id="v-pills-apps" role="tabpanel">
       <p>Authorized Applications — coming soon.</p>

--- a/test/controllers/passwords_test.rb
+++ b/test/controllers/passwords_test.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class PasswordsTest < ActionDispatch::IntegrationTest
+  test "the forgot password page renders the email field" do
+    get new_user_password_path
+
+    assert_select "input[name='user[email]']"
+  end
+
+  test "the forgot password page renders outside the application navbar" do
+    get new_user_password_path
+
+    assert_select "nav.navbar-light", false
+  end
+
+  test "the reset password page renders the new password fields" do
+    get edit_user_password_path(reset_password_token: "a-token")
+
+    assert_select "input[name='user[password]']"
+    assert_select "input[name='user[password_confirmation]']"
+  end
+
+  test "the reset password page renders outside the application navbar" do
+    get edit_user_password_path(reset_password_token: "a-token")
+
+    assert_select "nav.navbar-light", false
+  end
+end

--- a/test/controllers/passwords_test.rb
+++ b/test/controllers/passwords_test.rb
@@ -27,4 +27,17 @@ class PasswordsTest < ActionDispatch::IntegrationTest
 
     assert_select "nav.navbar-light", false
   end
+
+  test "the forgot password page labels its input" do
+    get new_user_password_path
+
+    assert_select "label[for='user_email']"
+  end
+
+  test "the reset password page labels every input" do
+    get edit_user_password_path(reset_password_token: "a-token")
+
+    assert_select "label[for='user_password']"
+    assert_select "label[for='user_password_confirmation']"
+  end
 end

--- a/test/controllers/registrations_test.rb
+++ b/test/controllers/registrations_test.rb
@@ -78,4 +78,14 @@ class RegistrationsTest < ActionDispatch::IntegrationTest
       password_confirmation: "password123"
     }
   end
+
+  test "the sign up page labels every input" do
+    get new_user_registration_path
+
+    assert_select "label[for='user_email']"
+    assert_select "label[for='user_name']"
+    assert_select "label[for='user_username']"
+    assert_select "label[for='user_password']"
+    assert_select "label[for='user_password_confirmation']"
+  end
 end

--- a/test/controllers/registrations_test.rb
+++ b/test/controllers/registrations_test.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class RegistrationsTest < ActionDispatch::IntegrationTest
+  test "signing up persists the submitted username" do
+    post user_registration_path, params: { user: sign_up_params }
+
+    assert_equal "newcomer", User.find_by(email: "newcomer@instuigram.com").username
+  end
+
+  test "signing up persists the submitted name" do
+    post user_registration_path, params: { user: sign_up_params }
+
+    assert_equal "New Comer", User.find_by(email: "newcomer@instuigram.com").name
+  end
+
+  test "the sign up page renders the username and name fields" do
+    get new_user_registration_path
+
+    assert_select "input[name='user[username]']"
+    assert_select "input[name='user[name]']"
+  end
+
+  test "the sign up page renders outside the application navbar" do
+    get new_user_registration_path
+
+    assert_select "nav.navbar-light", false
+  end
+
+  private
+
+  def sign_up_params
+    {
+      email: "newcomer@instuigram.com",
+      name: "New Comer",
+      username: "newcomer",
+      password: "password123",
+      password_confirmation: "password123"
+    }
+  end
+end

--- a/test/controllers/registrations_test.rb
+++ b/test/controllers/registrations_test.rb
@@ -28,6 +28,45 @@ class RegistrationsTest < ActionDispatch::IntegrationTest
     assert_select "nav.navbar-light", false
   end
 
+  test "the change password page renders the password fields" do
+    sign_in users(:one)
+
+    get edit_user_registration_path
+
+    assert_select "input[name='user[current_password]']"
+    assert_select "input[name='user[password]']"
+    assert_select "input[name='user[password_confirmation]']"
+  end
+
+  test "the change password page omits the profile fields owned by the profile form" do
+    sign_in users(:one)
+
+    get edit_user_registration_path
+
+    assert_select "input[name='user[email]']", false
+  end
+
+  test "the change password page keeps the application navbar" do
+    sign_in users(:one)
+
+    get edit_user_registration_path
+
+    assert_select "nav.navbar-light"
+  end
+
+  test "a wrong current password leaves the password unchanged" do
+    user = users(:one)
+    sign_in user
+
+    put user_registration_path, params: { user: {
+      current_password: "wrong-password",
+      password: "brand-new-password",
+      password_confirmation: "brand-new-password"
+    } }
+
+    assert user.reload.valid_password?("password123")
+  end
+
   private
 
   def sign_up_params

--- a/test/controllers/sessions_test.rb
+++ b/test/controllers/sessions_test.rb
@@ -22,4 +22,11 @@ class SessionsTest < ActionDispatch::IntegrationTest
     assert_select "a[href=?]", new_user_registration_path
     assert_select "a[href=?]", new_user_password_path
   end
+
+  test "the sign in page labels every input" do
+    get new_user_session_path
+
+    assert_select "label[for='user_email']"
+    assert_select "label[for='user_password']"
+  end
 end

--- a/test/controllers/sessions_test.rb
+++ b/test/controllers/sessions_test.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class SessionsTest < ActionDispatch::IntegrationTest
+  test "the sign in page renders the email and password fields" do
+    get new_user_session_path
+
+    assert_select "input[name='user[email]']"
+    assert_select "input[name='user[password]']"
+  end
+
+  test "the sign in page renders outside the application navbar" do
+    get new_user_session_path
+
+    assert_select "nav.navbar-light", false
+  end
+
+  test "the sign in page links to sign up and to password recovery" do
+    get new_user_session_path
+
+    assert_select "a[href=?]", new_user_registration_path
+    assert_select "a[href=?]", new_user_password_path
+  end
+end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -107,4 +107,12 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
 
     assert_not_equal "not-an-email", users(:one).reload.email
   end
+
+  test "edit, when authenticated, links the settings sidebar to the change password page" do
+    sign_in users(:one)
+
+    get edit_user_path(users(:one))
+
+    assert_select "a[href=?]", edit_user_registration_path
+  end
 end

--- a/test/system/settings_test.rb
+++ b/test/system/settings_test.rb
@@ -1,0 +1,22 @@
+require "application_system_test_case"
+
+class SettingsTest < ApplicationSystemTestCase
+  setup do
+    Post.find_each { |post| attach_test_image(post.image) }
+    sign_in_as users(:one)
+    visit edit_user_path(users(:one))
+    wait_for_page_to_settle
+  end
+
+  test "selecting a settings tab opens that tab's own pane" do
+    click_link "Privacy and Security"
+
+    assert_selector "#v-pills-privacy.active", text: "Privacy and Security"
+  end
+
+  test "selecting a settings tab hides the profile form" do
+    click_link "Authorized Applications"
+
+    assert_no_selector "#v-pills-home.active"
+  end
+end


### PR DESCRIPTION
Replaces Devise's stock unstyled views with an Instagram-style auth surface, and fills in the "Change Password — coming soon" placeholder in the profile settings sidebar.

## What changed

**Signed-out pages** (sign in, sign up, forgot password, reset password) now render in a dedicated `layouts/auth.html.erb` — no navbar, phone mockup on the left, bordered card on the right. Layout selection is the standard Devise idiom in `ApplicationController`:

```ruby
layout :layout_by_resource

def layout_by_resource
  devise_controller? && !user_signed_in? ? "auth" : "application"
end
```

The `!user_signed_in?` clause is what keeps the signed-in change-password page on the normal app layout.

**No new binary asset** — the phone mockup is drawn in SCSS and framed around the existing `app/assets/images/home_page.png`. It's hidden below 992px, so mobile gets just the card.

**Sign up** now collects email, full name, username, and password. `username`/`name` were already columns but Devise only permitted email/password, so this adds a `configure_permitted_parameters` before_action.

**Change password** is Devise's own `registrations#edit` rather than a JS tab. The settings sidebar was extracted to `users/_settings_nav.html.erb` and is shared by `users/edit` and `devise/registrations/edit`, so it looks identical to a tab, but `current_password` verification, error rendering, and `bypass_sign_in` all come from Devise with **zero controller or route changes**.

Devise's generated `shared/_links.html.erb` is deleted — nothing references it once each page spells out its own links.

## Commits

Each one leaves the suite green on its own (verified individually: 275 → 275 → 278 → 282 → 286 → 291 runs):

1. Extract the application layout footer into a shared partial
2. Render Devise views for signed-out visitors in a dedicated auth layout
3. Restyle the sign in page as an Instagram split screen
4. Collect a username and name on sign up
5. Restyle the password recovery pages to match the sign in screen
6. Replace the change password placeholder with a real settings page

