### PR TITLE
Improve Home feed and Search test coverage

### DIFF
--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -21,6 +21,12 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
     assert_current_path root_path
   end
 
+  def browser_readable_fixture_file(filename)
+    path = File.join(Dir.tmpdir, "instuigram_system_test_#{filename}")
+    FileUtils.cp(file_fixture(filename), path)
+    path
+  end
+
   def wait_for_page_to_settle
     wait_for_script "window.Turbo !== undefined && window.Turbo.session.started"
     wait_for_script "window.Stimulus !== undefined"

--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -17,10 +17,51 @@ class HomeControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
-  test "renders the feed with a bounded number of queries regardless of post count" do
+  test "with no avatar, shows the fallback icon in the composer" do
     sign_in users(:one)
 
-    assert_queries_count(11) { get root_path }
+    get root_path
+
+    assert_select ".composer-avatar i.fa-user"
+  end
+
+  test "with no posts, shows the empty state" do
+    sign_in users(:one)
+    Post.destroy_all
+
+    get root_path
+
+    assert_select ".empty-state"
+    assert_select "section.post", count: 0
+  end
+
+  test "requesting a page past the last page shows the empty state" do
+    sign_in users(:one)
+
+    get root_path(page: 2)
+
+    assert_response :success
+    assert_select ".empty-state"
+  end
+
+  test "renders the feed with a bounded number of queries regardless of post count" do
+    sign_in users(:one)
+    get root_path
+
+    11.times { |n| create_post!(users(:one), description: "post #{n}") }
+    assert_queries_count(10) { get root_path }
+
+    10.times { |n| create_post!(users(:one), description: "later post #{n}") }
+    assert_queries_count(10) { get root_path }
+  end
+
+  test "shows no filled hearts for a user who has reacted to no posts" do
+    sign_in users(:one)
+
+    get root_path
+
+    assert_select ".reaction-icon", count: 2
+    assert_select ".reaction-icon.liked", count: 0
   end
 
   test "shows the filled heart only for posts the signed-in user has reacted to" do
@@ -56,8 +97,19 @@ class HomeControllerTest < ActionDispatch::IntegrationTest
 
     get root_path
     assert_select "section.post", count: 10
+    assert_select "nav.pagination"
 
     get root_path(page: 2)
     assert_select "section.post", count: 3
+  end
+
+  test "with a non-numeric page param, falls back to the first page" do
+    sign_in users(:one)
+    11.times { |n| create_post!(users(:one), description: "post #{n}") }
+
+    get root_path(page: "not-a-number")
+
+    assert_response :success
+    assert_select "section.post", count: 10
   end
 end

--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -17,12 +17,13 @@ class HomeControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
-  test "with no avatar, shows the fallback icon in the composer" do
+  test "with no avatar, shows a placeholder instead of an image in the composer" do
     sign_in users(:one)
 
     get root_path
 
-    assert_select ".composer-avatar i.fa-user"
+    assert_select ".composer-avatar"
+    assert_select ".composer-avatar img", count: 0
   end
 
   test "with no posts, shows the empty state" do
@@ -32,7 +33,6 @@ class HomeControllerTest < ActionDispatch::IntegrationTest
     get root_path
 
     assert_select ".empty-state"
-    assert_select "section.post", count: 0
   end
 
   test "requesting a page past the last page shows the empty state" do
@@ -45,14 +45,23 @@ class HomeControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "renders the feed with a bounded number of queries regardless of post count" do
+    sign_in_and_absorb_trackable_update users(:one)
+    11.times { |n| create_post!(users(:one), description: "post #{n}") }
+
+    assert_queries_count(10) { get root_path }
+
+    create_post!(users(:one), description: "one more post")
+
+    assert_queries_count(10) { get root_path }
+  end
+
+  test "shows the newest post first" do
     sign_in users(:one)
+    newest = create_post!(users(:one), description: "the newest post")
+
     get root_path
 
-    11.times { |n| create_post!(users(:one), description: "post #{n}") }
-    assert_queries_count(10) { get root_path }
-
-    10.times { |n| create_post!(users(:one), description: "later post #{n}") }
-    assert_queries_count(10) { get root_path }
+    assert_select "section.post:first-of-type", text: /#{newest.description}/
   end
 
   test "shows no filled hearts for a user who has reacted to no posts" do
@@ -97,19 +106,25 @@ class HomeControllerTest < ActionDispatch::IntegrationTest
 
     get root_path
     assert_select "section.post", count: 10
-    assert_select "nav.pagination"
+    assert_select "a[href=?]", root_path(page: 2)
 
     get root_path(page: 2)
-    assert_select "section.post", count: 3
+    assert_select "section.post", count: Post.count - 10
   end
 
-  test "with a non-numeric page param, falls back to the first page" do
+  test "with a non-numeric page param, renders the first page without erroring" do
     sign_in users(:one)
-    11.times { |n| create_post!(users(:one), description: "post #{n}") }
 
     get root_path(page: "not-a-number")
 
     assert_response :success
-    assert_select "section.post", count: 10
+    assert_select "section.post", count: Post.count
+  end
+
+  private
+
+  def sign_in_and_absorb_trackable_update(user)
+    sign_in user
+    get root_path
   end
 end

--- a/test/controllers/search_controller_test.rb
+++ b/test/controllers/search_controller_test.rb
@@ -36,6 +36,32 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
     assert_select "h1", "Oop! No matching posts ..."
   end
 
+  test "paginates matching posts 10 per page" do
+    index_matching_posts(11)
+
+    get search_path(query: "pagination marker")
+    assert_select ".user-images .wrapper", count: 10
+
+    get search_path(query: "pagination marker", page: 2)
+    assert_select ".user-images .wrapper", count: 1
+  end
+
+  test "with a page past the last one, shows no matching posts" do
+    index_matching_posts(11)
+
+    get search_path(query: "pagination marker", page: 99)
+
+    assert_response :success
+    assert_select "h1", "Oop! No matching posts ..."
+  end
+
+  test "with a multi-word query, finds the post whose description contains those words" do
+    get search_path(query: "walk beach")
+
+    assert_select "h1", "Top Posts"
+    assert_select "a[href=?]", post_path(posts(:two))
+  end
+
   test "avoids N+1 queries when rendering multiple matching posts" do
     perform_enqueued_jobs do
       create_post!(users(:one), description: "shared marker one")
@@ -47,5 +73,13 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
 
     assert_select "h1", "Top Posts"
     assert_select ".user-images .wrapper", count: 2
+  end
+
+  private
+
+  def index_matching_posts(count)
+    count.times { |n| create_post!(users(:one), description: "pagination marker #{n}") }
+    perform_enqueued_jobs
+    Post.__elasticsearch__.refresh_index!
   end
 end

--- a/test/controllers/search_controller_test.rb
+++ b/test/controllers/search_controller_test.rb
@@ -1,6 +1,8 @@
 require "test_helper"
 
 class SearchControllerTest < ActionDispatch::IntegrationTest
+  MATCHING_MARKER = "pagination marker".freeze
+
   setup { index_all_posts! }
 
   test "with a blank query, shows no matching posts" do
@@ -39,17 +41,17 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
   test "paginates matching posts 10 per page" do
     index_matching_posts(11)
 
-    get search_path(query: "pagination marker")
+    get search_path(query: MATCHING_MARKER)
     assert_select ".user-images .wrapper", count: 10
 
-    get search_path(query: "pagination marker", page: 2)
+    get search_path(query: MATCHING_MARKER, page: 2)
     assert_select ".user-images .wrapper", count: 1
   end
 
   test "with a page past the last one, shows no matching posts" do
-    index_matching_posts(11)
+    index_matching_posts(1)
 
-    get search_path(query: "pagination marker", page: 99)
+    get search_path(query: MATCHING_MARKER, page: 99)
 
     assert_response :success
     assert_select "h1", "Oop! No matching posts ..."
@@ -63,11 +65,9 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "avoids N+1 queries when rendering multiple matching posts" do
-    perform_enqueued_jobs do
-      create_post!(users(:one), description: "shared marker one")
-      create_post!(users(:two), description: "shared marker two")
-    end
-    Post.__elasticsearch__.refresh_index!
+    create_post!(users(:one), description: "shared marker one")
+    create_post!(users(:two), description: "shared marker two")
+    index_pending_posts!
 
     assert_queries_count(3) { get search_path(query: "shared marker") }
 
@@ -78,8 +78,7 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
   private
 
   def index_matching_posts(count)
-    count.times { |n| create_post!(users(:one), description: "pagination marker #{n}") }
-    perform_enqueued_jobs
-    Post.__elasticsearch__.refresh_index!
+    count.times { |n| create_post!(users(:one), description: "#{MATCHING_MARKER} #{n}") }
+    index_pending_posts!
   end
 end

--- a/test/models/post/searchable_test.rb
+++ b/test/models/post/searchable_test.rb
@@ -1,0 +1,39 @@
+require "test_helper"
+
+class Post::SearchableTest < ActiveSupport::TestCase
+  setup { index_all_posts! }
+
+  test "finds the same posts whether or not the query is written with a leading #" do
+    hashtag_results = Post.search("##{hash_tags(:one).name}").records.map(&:id)
+    plain_results   = Post.search(hash_tags(:one).name).records.map(&:id)
+
+    assert_includes hashtag_results, posts(:one).id
+    assert_equal plain_results, hashtag_results
+  end
+
+  test "ranks a hashtag match above a description-only match" do
+    tagged, described = index_posts(
+      "a photo of a #capybara at dusk",
+      "capybara spotted by the river"
+    )
+
+    results = Post.search("capybara").records.map(&:id)
+
+    assert_equal [ tagged.id, described.id ], results
+  end
+
+  test "tolerates a single-character typo in the query" do
+    results = Post.search("sunst").records.map(&:id)
+
+    assert_includes results, posts(:one).id
+  end
+
+  private
+
+  def index_posts(*descriptions)
+    posts = descriptions.map { |description| create_post!(users(:one), description: description) }
+    perform_enqueued_jobs
+    Post.__elasticsearch__.refresh_index!
+    posts
+  end
+end

--- a/test/models/post/searchable_test.rb
+++ b/test/models/post/searchable_test.rb
@@ -4,36 +4,28 @@ class Post::SearchableTest < ActiveSupport::TestCase
   setup { index_all_posts! }
 
   test "finds the same posts whether or not the query is written with a leading #" do
-    hashtag_results = Post.search("##{hash_tags(:one).name}").records.map(&:id)
-    plain_results   = Post.search(hash_tags(:one).name).records.map(&:id)
+    hashtag_results = search_ids("##{hash_tags(:one).name}")
+    plain_results   = search_ids(hash_tags(:one).name)
 
     assert_includes hashtag_results, posts(:one).id
     assert_equal plain_results, hashtag_results
   end
 
   test "ranks a hashtag match above a description-only match" do
-    tagged, described = index_posts(
-      "a photo of a #capybara at dusk",
-      "capybara spotted by the river"
-    )
+    tagged    = create_post!(users(:one), description: "a photo of a #capybara at dusk")
+    described = create_post!(users(:one), description: "capybara spotted by the river")
+    index_pending_posts!
 
-    results = Post.search("capybara").records.map(&:id)
-
-    assert_equal [ tagged.id, described.id ], results
+    assert_equal [ tagged.id, described.id ], search_ids("capybara")
   end
 
   test "tolerates a single-character typo in the query" do
-    results = Post.search("sunst").records.map(&:id)
-
-    assert_includes results, posts(:one).id
+    assert_includes search_ids("sunst"), posts(:one).id
   end
 
   private
 
-  def index_posts(*descriptions)
-    posts = descriptions.map { |description| create_post!(users(:one), description: description) }
-    perform_enqueued_jobs
-    Post.__elasticsearch__.refresh_index!
-    posts
+  def search_ids(query)
+    Post.search(query).records.map(&:id)
   end
 end

--- a/test/models/post_test.rb
+++ b/test/models/post_test.rb
@@ -53,12 +53,12 @@ class PostTest < ActiveSupport::TestCase
   end
 
   test "created_recently orders posts newest first" do
-    older = travel_to(2.days.ago) { build_post(description: "older").tap(&:save!) }
-    newer = travel_to(1.day.ago) { build_post(description: "newer").tap(&:save!) }
+    older = travel_to(2.days.ago) { create_post!(@user, description: "older") }
+    newer = travel_to(1.day.ago) { create_post!(@user, description: "newer") }
 
-    ordered = Post.created_recently.to_a
+    ordered = Post.where(id: [ older.id, newer.id ]).created_recently.to_a
 
-    assert_operator ordered.index(newer), :<, ordered.index(older)
+    assert_equal [ newer, older ], ordered
   end
 
   test "extracts every #word token from the description" do

--- a/test/models/post_test.rb
+++ b/test/models/post_test.rb
@@ -52,6 +52,15 @@ class PostTest < ActiveSupport::TestCase
     assert posts(:one).image.attached?
   end
 
+  test "created_recently orders posts newest first" do
+    older = travel_to(2.days.ago) { build_post(description: "older").tap(&:save!) }
+    newer = travel_to(1.day.ago) { build_post(description: "newer").tap(&:save!) }
+
+    ordered = Post.created_recently.to_a
+
+    assert_operator ordered.index(newer), :<, ordered.index(older)
+  end
+
   test "extracts every #word token from the description" do
     post = build_post(description: "loving this #sunset over the #beach today", attach_image: false)
 

--- a/test/system/posts_test.rb
+++ b/test/system/posts_test.rb
@@ -1,0 +1,38 @@
+require "application_system_test_case"
+
+class PostsTest < ApplicationSystemTestCase
+  setup do
+    sign_in_as users(:one)
+    wait_for_page_to_settle
+  end
+
+  test "creating a post from the composer shows it in the feed" do
+    fill_in "post_description", with: "a fresh #capybara photo"
+    attach_file "post_image", browser_readable_test_image, make_visible: true
+
+    click_button "Post"
+
+    assert_selector "section.post", text: "a fresh #capybara photo"
+    assert_selector "section.post", count: 3
+  end
+
+  test "deleting your own post removes it from the feed" do
+    find("section.post", text: posts(:one).description).find(".main-image-link").click
+
+    accept_confirm { find(".delete-icon").click }
+
+    assert_current_path user_path(users(:one))
+
+    visit root_path
+
+    assert_no_selector "section.post", text: posts(:one).description
+  end
+
+  private
+
+  def browser_readable_test_image
+    path = File.join(Dir.tmpdir, "instuigram_system_test_image.png")
+    FileUtils.cp(file_fixture("test_image.png"), path)
+    path
+  end
+end

--- a/test/system/posts_test.rb
+++ b/test/system/posts_test.rb
@@ -8,12 +8,11 @@ class PostsTest < ApplicationSystemTestCase
 
   test "creating a post from the composer shows it in the feed" do
     fill_in "post_description", with: "a fresh #capybara photo"
-    attach_file "post_image", browser_readable_test_image, make_visible: true
+    attach_file "post_image", browser_readable_fixture_file("test_image.png"), make_visible: true
 
     click_button "Post"
 
     assert_selector "section.post", text: "a fresh #capybara photo"
-    assert_selector "section.post", count: 3
   end
 
   test "deleting your own post removes it from the feed" do
@@ -21,18 +20,8 @@ class PostsTest < ApplicationSystemTestCase
 
     accept_confirm { find(".delete-icon").click }
 
-    assert_current_path user_path(users(:one))
-
     visit root_path
 
     assert_no_selector "section.post", text: posts(:one).description
-  end
-
-  private
-
-  def browser_readable_test_image
-    path = File.join(Dir.tmpdir, "instuigram_system_test_image.png")
-    FileUtils.cp(file_fixture("test_image.png"), path)
-    path
   end
 end

--- a/test/system/posts_test.rb
+++ b/test/system/posts_test.rb
@@ -19,6 +19,7 @@ class PostsTest < ApplicationSystemTestCase
     find("section.post", text: posts(:one).description).find(".main-image-link").click
 
     accept_confirm { find(".delete-icon").click }
+    assert_current_path user_path(users(:one))
 
     visit root_path
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -45,6 +45,11 @@ module PostTestHelper
     Post.find_each { |post| post.__elasticsearch__.index_document }
     Post.__elasticsearch__.refresh_index!
   end
+
+  def index_pending_posts!
+    perform_enqueued_jobs
+    Post.__elasticsearch__.refresh_index!
+  end
 end
 
 class ActiveSupport::TestCase


### PR DESCRIPTION
Improves test coverage for the two core read paths — the Home feed and Search — closing gaps that let real regressions through. Test-only: no application code changes.

## Why

- `Post.created_recently`, the scope ordering the whole feed, had no test at all.
- The N+1 guard asserted `assert_queries_count(11)` against only the 2 fixture posts, so it never varied N — it could not prove the thing its name claimed.
- No coverage for the empty feed, a user with zero reactions, or any pagination edge.
- `.claude/rules/testing.md` documents an expected `test/system/posts_test.rb` ("sign in → create a post → see it in the feed; delete your own post") that was never written.
- Search had no coverage of pagination past page 1, and neither of the two behaviours that make search useful — the `hashtag_names^3` field and `fuzziness: "AUTO"` — was asserted.

## What's added

14 tests across 5 files:

- **`post_test.rb`** — `created_recently` orders newest first.
- **`home_controller_test.rb`** — empty state; empty state when paging past the last page; zero-reaction user; composer avatar fallback; non-numeric `page` param; newest-post-first; pagination nav link; strengthened query-count guard.
- **`post/searchable_test.rb`** (new) — hashtag-vs-description ranking, single-character typo tolerance, and `#tag` ≡ `tag` equivalence.
- **`search_controller_test.rb`** — result pagination, out-of-range page, multi-word query.
- **`system/posts_test.rb`** (new) — the two end-to-end flows `testing.md` specifies.

Each significant test was verified to **fail when the behaviour it guards is broken**, not merely to pass: reversing `created_recently` fails the ordering test, removing `hashtag_names` from the searched fields fails the ranking test, removing `fuzziness: "AUTO"` fails the typo test, and removing `.created_recently` from `HomeController` fails the newest-first test.

## Findings worth reviewer attention

**1. A latent indexing race (not fixed here).** `include Searchable` (`app/models/post.rb:2`) registers `enqueue_indexing` *before* `after_commit :create_hash_tags` (line 17), so `IndexPostJob` can run before the hashtags exist. Confirmed concretely: the indexed document came back `hashtag_names: []` while the DB held `["capybara"]`. In production Sidekiq usually dequeues late enough, but nothing guarantees it — a fast worker indexes the post before the hashtag rows commit, and that post stays unfindable by hashtag search, since there is no update callback to repair it. Left alone as out of scope for a test-only change; worth its own issue.

**2. `delete_prefix("#")` in `Post.search` is effectively dead code.** The `#`-stripping test passes with the line removed — Elasticsearch's standard analyzer already strips `#` at tokenization. The test is kept because it locks in the user-facing contract, but it is named so it does not claim to cover that line.

**3. The ranking test guards field inclusion, not boost magnitude.** Removing `hashtag_names` from `fields` fails it; removing `^3` does not. Pinning the boost would require tuning BM25 field lengths until only the boost flips the order — brittle across ES versions, so deliberately not done.

**4. The old N+1 number was partly noise.** `11` included Devise `trackable`'s one-time sign-in UPDATE plus its transaction; the steady-state count is `10`. The feed is genuinely free of N+1s — Bullet is already configured to raise in test (`config/environments/test.rb:63`), and this guard adds total-query-count invariance on top.

## Notes

- One system-test flake was observed in ~14 runs, in the shared `sign_in_as`/`wait_for_page_to_settle` setup path — pre-existing helpers `comments_test.rb` uses identically. Not reproducible in 10 subsequent runs.
- `browser_readable_fixture_file` lives in `ApplicationSystemTestCase` because macOS denies Chrome read access to files under `~/Documents`, making `attach_file` fail with `ERR_ACCESS_DENIED`. It is in the base class so the next author to write an upload test does not rediscover this — the project forbids code comments, so the name carries the intent.

## Verification

```
bin/rails test          # 288 runs, 698 assertions, 0 failures, 0 errors
bin/rails test:system   # 7 runs, 26 assertions, 0 failures, 0 errors
bundle exec rubocop     # 149 files inspected, no offenses detected
```

