### PR TITLE
Add a follow button to the post header

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -16,6 +16,7 @@
 @import "components/footer";
 @import "components/comment";
 @import "components/reaction";
+@import "components/follow";
 @import "components/modal";
 
 @import "pages/auth";

--- a/app/assets/stylesheets/components/_button.scss
+++ b/app/assets/stylesheets/components/_button.scss
@@ -12,7 +12,7 @@
   cursor: pointer;
 }
 
-.btn-accent {
+%btn-accent {
   @extend %btn-base;
   background-color: $accent;
   color: $ink-inverse;
@@ -30,7 +30,7 @@
   }
 }
 
-.btn-outline {
+%btn-outline {
   @extend %btn-base;
   border-color: $border;
   background-color: transparent;
@@ -42,6 +42,14 @@
     color: $ink;
     text-decoration: none;
   }
+}
+
+.btn-accent {
+  @extend %btn-accent;
+}
+
+.btn-outline {
+  @extend %btn-outline;
 }
 
 .btn-block {

--- a/app/assets/stylesheets/components/_follow.scss
+++ b/app/assets/stylesheets/components/_follow.scss
@@ -18,7 +18,3 @@
     background-color: $border;
   }
 }
-
-.user .follow-control__button.is-following {
-  display: none;
-}

--- a/app/assets/stylesheets/components/_follow.scss
+++ b/app/assets/stylesheets/components/_follow.scss
@@ -18,3 +18,7 @@
     background-color: $border;
   }
 }
+
+.user .follow-control__button.is-following {
+  display: none;
+}

--- a/app/assets/stylesheets/components/_follow.scss
+++ b/app/assets/stylesheets/components/_follow.scss
@@ -3,10 +3,11 @@
 }
 
 .follow-control__button {
-  padding: 0;
+  padding: $space-2 $space-4;
   border: none;
-  background: none;
-  color: $accent;
+  border-radius: $radius-md;
+  background-color: $border-subtle;
+  color: $ink;
   font-size: $text-base;
   font-weight: $weight-semibold;
   line-height: $leading-tight;
@@ -14,15 +15,6 @@
 
   &:hover,
   &:focus {
-    color: $accent-hover;
-  }
-
-  &.is-following {
-    color: $ink-muted;
-
-    &:hover,
-    &:focus {
-      color: $ink;
-    }
+    background-color: $border;
   }
 }

--- a/app/assets/stylesheets/components/_follow.scss
+++ b/app/assets/stylesheets/components/_follow.scss
@@ -1,0 +1,28 @@
+.follow-control {
+  display: inline-flex;
+}
+
+.follow-control__button {
+  padding: 0;
+  border: none;
+  background: none;
+  color: $accent;
+  font-size: $text-base;
+  font-weight: $weight-semibold;
+  line-height: $leading-tight;
+  cursor: pointer;
+
+  &:hover,
+  &:focus {
+    color: $accent-hover;
+  }
+
+  &.is-following {
+    color: $ink-muted;
+
+    &:hover,
+    &:focus {
+      color: $ink;
+    }
+  }
+}

--- a/app/assets/stylesheets/pages/_home.scss
+++ b/app/assets/stylesheets/pages/_home.scss
@@ -90,6 +90,10 @@
         border-bottom: 1px solid $border-subtle;
       }
 
+      .follow-control {
+        margin-left: auto;
+      }
+
       .avatar {
         @include avatar(36px);
       }

--- a/app/assets/stylesheets/pages/_post.scss
+++ b/app/assets/stylesheets/pages/_post.scss
@@ -38,6 +38,10 @@
     border-bottom: 1px solid $border-subtle;
   }
 
+  .follow-control {
+    margin-left: auto;
+  }
+
   .avatar {
     @include avatar(44px);
   }

--- a/app/assets/stylesheets/pages/_profile.scss
+++ b/app/assets/stylesheets/pages/_profile.scss
@@ -21,6 +21,14 @@
   flex-wrap: wrap;
   gap: $space-5;
   margin-bottom: $space-5;
+
+  .follow-control__button {
+    @extend %btn-accent;
+
+    &.is-following {
+      @extend %btn-outline;
+    }
+  }
 }
 
 .profile-header__username {

--- a/app/controllers/follows_controller.rb
+++ b/app/controllers/follows_controller.rb
@@ -26,7 +26,7 @@ class FollowsController < ApplicationController
   def render_follow_state
     respond_to do |format|
       format.turbo_stream { render :create }
-      format.html { redirect_to user_path(@user) }
+      format.html { redirect_back fallback_location: user_path(@user) }
     end
   end
 end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -6,6 +6,9 @@ class HomeController < ApplicationController
                           .created_recently
                           .page(params[:page]).per(10).without_count
     @user_reactions = current_user.reactions.where(reactable: @posts).index_by(&:reactable_id)
+    @following_ids  = current_user.following_relationships
+                                  .where(followed_id: @posts.map(&:user_id))
+                                  .pluck(:followed_id).to_set
 
     respond_to do |format|
       format.html

--- a/app/services/follows/broadcast_button.rb
+++ b/app/services/follows/broadcast_button.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class Follows::BroadcastButton < BaseService
+  def initialize(follower:, followed:, following:)
+    @follower  = follower
+    @followed  = followed
+    @following = following
+  end
+
+  def call
+    Turbo::StreamsChannel.broadcast_action_to(
+      [ follower, :follow_state ],
+      action:  :replace,
+      targets: "[data-follow-user-id='#{followed.id}']",
+      partial: "users/follow_button",
+      locals:  { user: followed, following: following }
+    )
+  end
+
+  private
+
+  attr_reader :follower, :followed, :following
+end

--- a/app/services/follows/create.rb
+++ b/app/services/follows/create.rb
@@ -8,7 +8,7 @@ class Follows::Create < BaseService
 
   def call
     follow = find_follow || create_follow
-    broadcast_counts if follow&.previously_new_record?
+    broadcast_changes if follow&.previously_new_record?
     follow
   end
 
@@ -26,7 +26,8 @@ class Follows::Create < BaseService
     find_follow
   end
 
-  def broadcast_counts
+  def broadcast_changes
     Follows::BroadcastCounts.call(follower: follower, followed: followed)
+    Follows::BroadcastButton.call(follower: follower, followed: followed, following: true)
   end
 end

--- a/app/services/follows/destroy.rb
+++ b/app/services/follows/destroy.rb
@@ -10,7 +10,7 @@ class Follows::Destroy < BaseService
     follow = Follow.find_by(follower: follower, followed: followed)
     return unless follow&.destroy
 
-    broadcast_counts
+    broadcast_changes
     follow
   end
 
@@ -18,7 +18,8 @@ class Follows::Destroy < BaseService
 
   attr_reader :follower, :followed
 
-  def broadcast_counts
+  def broadcast_changes
     Follows::BroadcastCounts.call(follower: follower, followed: followed)
+    Follows::BroadcastButton.call(follower: follower, followed: followed, following: false)
   end
 end

--- a/app/views/follows/create.turbo_stream.erb
+++ b/app/views/follows/create.turbo_stream.erb
@@ -1,4 +1,4 @@
-<%= turbo_stream.replace dom_id(@user, :follow) do %>
+<%= turbo_stream.replace_all "[data-follow-user-id='#{@user.id}']" do %>
   <%= render "users/follow_button", user: @user, following: current_user.following?(@user) %>
 <% end %>
 <%= turbo_stream.replace dom_id(@user, :followers_count) do %>

--- a/app/views/home/_post.html.erb
+++ b/app/views/home/_post.html.erb
@@ -1,8 +1,8 @@
 <section class="post">
+  <div class="user">
+    <%= render partial: "posts/user_header", locals: { user: post.user, avatar_size: 72, following: following } %>
+  </div>
   <% cache post do %>
-    <div class="user">
-      <%= render partial: "posts/user_header", locals: { user: post.user, avatar_size: 72 } %>
-    </div>
     <%= link_to post_path(post), class: 'main-image-link' do %>
       <%= image_tag post.image.variant(resize_to_limit: [ 600, 600 ]), class: 'main-image' %>
     <% end %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -6,7 +6,7 @@
   <% if @posts.load.any? %>
     <div class="posts" id="posts">
       <% @posts.each do |post| %>
-        <%= render partial: 'post', locals: { post: post, user_reaction: @user_reactions[post.id] } %>
+        <%= render partial: 'post', locals: { post: post, user_reaction: @user_reactions[post.id], following: @following_ids.include?(post.user_id) } %>
       <% end %>
     </div>
     <%= render "feed_sentinel", posts: @posts %>

--- a/app/views/home/index.turbo_stream.erb
+++ b/app/views/home/index.turbo_stream.erb
@@ -1,6 +1,6 @@
 <%= turbo_stream.append "posts" do %>
   <% @posts.each do |post| %>
-    <%= render partial: "post", locals: { post: post, user_reaction: @user_reactions[post.id] } %>
+    <%= render partial: "post", locals: { post: post, user_reaction: @user_reactions[post.id], following: @following_ids.include?(post.user_id) } %>
   <% end %>
 <% end %>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,6 +12,7 @@
   <body>
     <% if user_signed_in? %>
       <div id="realtime" data-turbo-permanent data-controller="inbox presence"></div>
+      <%= turbo_stream_from current_user, :follow_state %>
     <% end %>
 
     <!--Navigation Bar-->

--- a/app/views/posts/_detail.html.erb
+++ b/app/views/posts/_detail.html.erb
@@ -4,7 +4,7 @@
   </div>
   <div class="post-detail__panel">
     <div class="user">
-      <%= render partial: "posts/user_header", locals: { user: post.user, avatar_size: 88 } %>
+      <%= render partial: "posts/user_header", locals: { user: post.user, avatar_size: 88, following: current_user&.following?(post.user) } %>
     </div>
     <div class="description">
       <%= render partial: "posts/description", locals: { post: post } %>

--- a/app/views/posts/_user_header.html.erb
+++ b/app/views/posts/_user_header.html.erb
@@ -6,6 +6,6 @@
   <% end %>
 </div>
 <%= link_to user.username, user_path(user), class: 'username' %>
-<% if user_signed_in? && user != current_user %>
+<% if user_signed_in? && user != current_user && !following %>
   <%= render "users/follow_button", user: user, following: following %>
 <% end %>

--- a/app/views/posts/_user_header.html.erb
+++ b/app/views/posts/_user_header.html.erb
@@ -6,3 +6,6 @@
   <% end %>
 </div>
 <%= link_to user.username, user_path(user), class: 'username' %>
+<% if user_signed_in? && user != current_user %>
+  <%= render "users/follow_button", user: user, following: following %>
+<% end %>

--- a/app/views/users/_follow_button.html.erb
+++ b/app/views/users/_follow_button.html.erb
@@ -1,9 +1,11 @@
 <% if following %>
   <%= button_to "Following", user_follow_path(user), method: :delete,
-                form: { id: dom_id(user, :follow) },
-                class: "btn-outline", "aria-label": "Unfollow #{user.username}" %>
+                form: { class: "follow-control", data: { follow_user_id: user.id } },
+                class: "follow-control__button is-following",
+                "aria-label": "Unfollow #{user.username}" %>
 <% else %>
   <%= button_to "Follow", user_follow_path(user),
-                form: { id: dom_id(user, :follow) },
-                class: "btn-accent", "aria-label": "Follow #{user.username}" %>
+                form: { class: "follow-control", data: { follow_user_id: user.id } },
+                class: "follow-control__button",
+                "aria-label": "Follow #{user.username}" %>
 <% end %>

--- a/test/controllers/follows_controller_test.rb
+++ b/test/controllers/follows_controller_test.rb
@@ -72,6 +72,25 @@ class FollowsControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "following from the feed returns to the feed" do
+    sign_in @user
+    get root_path
+
+    post user_follow_path(@other), headers: { "HTTP_REFERER" => root_url }
+
+    assert_redirected_to root_url
+  end
+
+  test "unfollowing from the feed returns to the feed" do
+    sign_in @user
+    get root_path
+    post user_follow_path(@other)
+
+    delete user_follow_path(@other), headers: { "HTTP_REFERER" => root_url }
+
+    assert_redirected_to root_url
+  end
+
   test "following yourself creates no follow and alerts" do
     sign_in @user
 

--- a/test/controllers/follows_controller_test.rb
+++ b/test/controllers/follows_controller_test.rb
@@ -49,7 +49,9 @@ class FollowsControllerTest < ActionDispatch::IntegrationTest
     post user_follow_path(@other), as: :turbo_stream
 
     assert_response :success
-    assert_select "turbo-stream[action=replace][target=?]", dom_id(@other, :follow)
+    assert_select "turbo-stream[action=replace][targets=?]", "[data-follow-user-id='#{@other.id}']" do
+      assert_select "form[data-follow-user-id=?] button", @other.id.to_s, text: "Following"
+    end
     assert_select "turbo-stream[action=replace][target=?]", dom_id(@other, :followers_count) do
       assert_select "li span", text: "1"
     end
@@ -62,6 +64,9 @@ class FollowsControllerTest < ActionDispatch::IntegrationTest
     delete user_follow_path(@other), as: :turbo_stream
 
     assert_response :success
+    assert_select "turbo-stream[action=replace][targets=?]", "[data-follow-user-id='#{@other.id}']" do
+      assert_select "form[data-follow-user-id=?] button", @other.id.to_s, text: "Follow"
+    end
     assert_select "turbo-stream[action=replace][target=?]", dom_id(@other, :followers_count) do
       assert_select "li span", text: "0"
     end

--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -93,13 +93,13 @@ class HomeControllerTest < ActionDispatch::IntegrationTest
     assert_select "form[data-follow-user-id=?]", users(:one).id.to_s, count: 0
   end
 
-  test "shows the following state on posts by a user you already follow" do
+  test "stops offering Follow on posts by a user you already follow" do
     Follows::Create.call(follower: users(:one), followed: users(:two))
     sign_in users(:one)
 
     get root_path
 
-    assert_select "form[data-follow-user-id=?] button", users(:two).id.to_s, text: "Following"
+    assert_select "form[data-follow-user-id=?] button", users(:two).id.to_s, text: "Follow", count: 0
   end
 
   test "shows a comment icon opening the post popup for each post" do

--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -93,13 +93,13 @@ class HomeControllerTest < ActionDispatch::IntegrationTest
     assert_select "form[data-follow-user-id=?]", users(:one).id.to_s, count: 0
   end
 
-  test "stops offering Follow on posts by a user you already follow" do
+  test "shows no follow button on posts by a user you already follow" do
     Follows::Create.call(follower: users(:one), followed: users(:two))
     sign_in users(:one)
 
     get root_path
 
-    assert_select "form[data-follow-user-id=?] button", users(:two).id.to_s, text: "Follow", count: 0
+    assert_select "form[data-follow-user-id=?]", users(:two).id.to_s, count: 0
   end
 
   test "shows a comment icon opening the post popup for each post" do

--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -50,11 +50,11 @@ class HomeControllerTest < ActionDispatch::IntegrationTest
     sign_in_and_absorb_trackable_update users(:one)
     11.times { |n| create_post!(users(:one), description: "post #{n}") }
 
-    assert_queries_count(9) { get root_path }
+    assert_queries_count(10) { get root_path }
 
     create_post!(users(:one), description: "one more post")
 
-    assert_queries_count(9) { get root_path }
+    assert_queries_count(10) { get root_path }
   end
 
   test "shows the newest post first" do

--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -84,6 +84,24 @@ class HomeControllerTest < ActionDispatch::IntegrationTest
     assert_select ".reaction-icon.liked", count: 1
   end
 
+  test "shows a follow button on other users' posts and none on your own" do
+    sign_in users(:one)
+
+    get root_path
+
+    assert_select "form[data-follow-user-id=?] button", users(:two).id.to_s, text: "Follow"
+    assert_select "form[data-follow-user-id=?]", users(:one).id.to_s, count: 0
+  end
+
+  test "shows the following state on posts by a user you already follow" do
+    Follows::Create.call(follower: users(:one), followed: users(:two))
+    sign_in users(:one)
+
+    get root_path
+
+    assert_select "form[data-follow-user-id=?] button", users(:two).id.to_s, text: "Following"
+  end
+
   test "shows a comment icon opening the post popup for each post" do
     sign_in users(:one)
 

--- a/test/controllers/posts_controller_test.rb
+++ b/test/controllers/posts_controller_test.rb
@@ -94,6 +94,28 @@ class PostsControllerTest < ActionDispatch::IntegrationTest
     assert_select "a.delete-icon", count: 0
   end
 
+  test "when signed in as a different user, shows a follow button in the post header" do
+    sign_in users(:two)
+
+    get post_path(posts(:one))
+
+    assert_select ".post-detail .user form[data-follow-user-id=?] button", users(:one).id.to_s, text: "Follow"
+  end
+
+  test "when signed in as the post's owner, hides the follow button" do
+    sign_in users(:one)
+
+    get post_path(posts(:one))
+
+    assert_select ".follow-control", count: 0
+  end
+
+  test "when unauthenticated, hides the follow button" do
+    get post_path(posts(:one))
+
+    assert_select ".follow-control", count: 0
+  end
+
   test "when signed in and not yet reacted, shows an outline heart Like icon" do
     sign_in users(:one)
 

--- a/test/services/follows/broadcast_button_test.rb
+++ b/test/services/follows/broadcast_button_test.rb
@@ -1,0 +1,47 @@
+require "test_helper"
+
+class Follows::BroadcastButtonTest < ActiveSupport::TestCase
+  setup do
+    @follower = users(:one)
+    @followed = users(:two)
+  end
+
+  test "broadcasts a replace targeting every follow button for the followed user" do
+    broadcast = capture_broadcasts(follow_state_stream(@follower)) do
+      broadcast_button(following: true)
+    end.first
+
+    assert_includes broadcast, %(action="replace")
+    assert_includes broadcast, %(targets="[data-follow-user-id=&#39;#{@followed.id}&#39;]")
+  end
+
+  test "broadcasts the following state when the follow was created" do
+    broadcast = capture_broadcasts(follow_state_stream(@follower)) do
+      broadcast_button(following: true)
+    end.first
+
+    assert_includes broadcast, "Following"
+    assert_includes broadcast, "Unfollow #{@followed.username}"
+  end
+
+  test "broadcasts the follow state when the follow was destroyed" do
+    broadcast = capture_broadcasts(follow_state_stream(@follower)) do
+      broadcast_button(following: false)
+    end.first
+
+    assert_includes broadcast, "Follow #{@followed.username}"
+    assert_not_includes broadcast, "Unfollow"
+  end
+
+  test "broadcasts nothing to the followed user's own stream" do
+    assert_no_broadcasts(follow_state_stream(@followed)) do
+      broadcast_button(following: true)
+    end
+  end
+
+  private
+
+  def broadcast_button(following:)
+    Follows::BroadcastButton.call(follower: @follower, followed: @followed, following: following)
+  end
+end

--- a/test/services/follows/create_test.rb
+++ b/test/services/follows/create_test.rb
@@ -36,6 +36,18 @@ class Follows::CreateTest < ActiveSupport::TestCase
     assert_no_enqueued_jobs(only: Turbo::Streams::ActionBroadcastJob) { create_follow }
   end
 
+  test "broadcasts the following button to the follower's own stream" do
+    broadcast = capture_broadcasts(follow_state_stream(@follower)) { create_follow }.first
+
+    assert_includes broadcast, "Following"
+  end
+
+  test "following again broadcasts no button" do
+    create_follow
+
+    assert_no_broadcasts(follow_state_stream(@follower)) { create_follow }
+  end
+
   test "returns the winning row when a concurrent request wins the insert race" do
     follow = losing_the_insert_race { create_follow }
 

--- a/test/services/follows/destroy_test.rb
+++ b/test/services/follows/destroy_test.rb
@@ -37,6 +37,18 @@ class Follows::DestroyTest < ActiveSupport::TestCase
     assert_no_enqueued_jobs(only: Turbo::Streams::ActionBroadcastJob) { destroy_follow }
   end
 
+  test "broadcasts the follow button back to the follower's own stream" do
+    Follows::Create.call(follower: @follower, followed: @followed)
+
+    broadcast = capture_broadcasts(follow_state_stream(@follower)) { destroy_follow }.first
+
+    assert_includes broadcast, "Follow #{@followed.username}"
+  end
+
+  test "unfollowing someone you do not follow broadcasts no button" do
+    assert_no_broadcasts(follow_state_stream(@follower)) { destroy_follow }
+  end
+
   private
 
   def destroy_follow(follower: @follower, followed: @followed)

--- a/test/system/follows_test.rb
+++ b/test/system/follows_test.rb
@@ -30,7 +30,7 @@ class FollowsTest < ApplicationSystemTestCase
     assert_selector "##{dom_id(@other, :followers_count)}", text: "0 followers"
   end
 
-  test "following from a post in the feed flips that post's button" do
+  test "following from a post in the feed hides that post's button" do
     visit root_path
     wait_for_page_to_settle
 
@@ -38,7 +38,7 @@ class FollowsTest < ApplicationSystemTestCase
 
     click_button "Follow"
 
-    assert_selector "section.post #{follow_button_selector}", exact_text: "Following", count: 1
+    assert_no_selector "section.post #{follow_button_selector}"
   end
 
   test "following in one tab flips the button in another tab" do

--- a/test/system/follows_test.rb
+++ b/test/system/follows_test.rb
@@ -14,17 +14,17 @@ class FollowsTest < ApplicationSystemTestCase
 
     click_button "Follow"
 
-    assert_selector "##{dom_id(@other, :follow)} button", exact_text: "Following"
+    assert_selector "[data-follow-user-id='#{@other.id}'] button", exact_text: "Following"
     assert_selector "##{dom_id(@other, :followers_count)}", text: "1 followers"
   end
 
   test "unfollowing reverts the button and the follower count" do
     click_button "Follow"
-    assert_selector "##{dom_id(@other, :follow)} button", exact_text: "Following"
+    assert_selector "[data-follow-user-id='#{@other.id}'] button", exact_text: "Following"
 
     click_button "Following"
 
-    assert_selector "##{dom_id(@other, :follow)} button", exact_text: "Follow"
+    assert_selector "[data-follow-user-id='#{@other.id}'] button", exact_text: "Follow"
     assert_selector "##{dom_id(@other, :followers_count)}", text: "0 followers"
   end
 end

--- a/test/system/follows_test.rb
+++ b/test/system/follows_test.rb
@@ -5,26 +5,67 @@ class FollowsTest < ApplicationSystemTestCase
     Post.find_each { |post| attach_test_image(post.image) }
     @other = users(:two)
     sign_in_as users(:one)
-    visit user_path(@other)
-    wait_for_page_to_settle
   end
 
   test "following a user flips the button and updates the follower count in place" do
+    visit_profile
+
     assert_selector "##{dom_id(@other, :followers_count)}", text: "0 followers"
 
     click_button "Follow"
 
-    assert_selector "[data-follow-user-id='#{@other.id}'] button", exact_text: "Following"
+    assert_selector follow_button_selector, exact_text: "Following"
     assert_selector "##{dom_id(@other, :followers_count)}", text: "1 followers"
   end
 
   test "unfollowing reverts the button and the follower count" do
+    visit_profile
+
     click_button "Follow"
-    assert_selector "[data-follow-user-id='#{@other.id}'] button", exact_text: "Following"
+    assert_selector follow_button_selector, exact_text: "Following"
 
     click_button "Following"
 
-    assert_selector "[data-follow-user-id='#{@other.id}'] button", exact_text: "Follow"
+    assert_selector follow_button_selector, exact_text: "Follow"
     assert_selector "##{dom_id(@other, :followers_count)}", text: "0 followers"
+  end
+
+  test "following from a post in the feed flips that post's button" do
+    visit root_path
+    wait_for_page_to_settle
+
+    assert_selector "section.post #{follow_button_selector}", exact_text: "Follow", count: 1
+
+    click_button "Follow"
+
+    assert_selector "section.post #{follow_button_selector}", exact_text: "Following", count: 1
+  end
+
+  test "following in one tab flips the button in another tab" do
+    visit root_path
+    wait_for_page_to_settle
+
+    using_session :second_tab do
+      sign_in_as users(:one)
+      visit_profile
+      assert_selector follow_button_selector, exact_text: "Follow"
+    end
+
+    click_button "Follow"
+
+    using_session :second_tab do
+      assert_selector follow_button_selector, exact_text: "Following"
+    end
+  end
+
+  private
+
+  def visit_profile
+    visit user_path(@other)
+    wait_for_page_to_settle
+  end
+
+  def follow_button_selector
+    "[data-follow-user-id='#{@other.id}'] button"
   end
 end

--- a/test/system/follows_test.rb
+++ b/test/system/follows_test.rb
@@ -30,13 +30,28 @@ class FollowsTest < ApplicationSystemTestCase
     assert_selector "##{dom_id(@other, :followers_count)}", text: "0 followers"
   end
 
-  test "following from a post in the feed hides that post's button" do
+  test "following from a post in the feed leaves the button in place to undo it" do
     visit root_path
     wait_for_page_to_settle
 
     assert_selector "section.post #{follow_button_selector}", exact_text: "Follow", count: 1
 
     click_button "Follow"
+    assert_selector "section.post #{follow_button_selector}", exact_text: "Following", count: 1
+
+    click_button "Following"
+
+    assert_selector "section.post #{follow_button_selector}", exact_text: "Follow", count: 1
+  end
+
+  test "a followed user's posts carry no follow button on the next page load" do
+    visit root_path
+    wait_for_page_to_settle
+    click_button "Follow"
+    assert_selector "section.post #{follow_button_selector}", exact_text: "Following"
+
+    visit root_path
+    wait_for_page_to_settle
 
     assert_no_selector "section.post #{follow_button_selector}"
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -52,6 +52,12 @@ module PostTestHelper
   end
 end
 
+module TurboStreamTestHelper
+  def follow_state_stream(user)
+    Turbo::StreamsChannel.send(:stream_name_from, [ user, :follow_state ])
+  end
+end
+
 class ActiveSupport::TestCase
   parallelize(workers: :number_of_processors)
   parallelize_setup do |worker|
@@ -61,6 +67,7 @@ class ActiveSupport::TestCase
   fixtures :all
   include ActiveStorageTestHelper
   include PostTestHelper
+  include TurboStreamTestHelper
   include ActionCable::TestHelper
   include ActiveJob::TestHelper
   include ActionMailer::TestHelper


### PR DESCRIPTION
Follow was only reachable from a profile page — on the feed you had to click through to the author to follow them. This puts a Follow / Following control in the post header, to the right of the author, on the home feed and the post detail page/modal, and syncs it live across the viewer's open tabs.

## UI

An Instagram-style text link (accent `Follow` → muted `Following`), right-aligned in the header row that already holds the avatar and username. Hidden on your own posts and for signed-out visitors.

`users/_follow_button` stays the single source of the control and is restyled into the existing pill inside `.profile-header__identity`, so the profile page is visually unchanged. That mattered: opening a post modal *on someone's profile* puts both variants on the page for the same user at once, and one shared markup means one update keeps both in sync. To make the pill reachable from another context, `.btn-accent` / `.btn-outline` were split into `%btn-accent` / `%btn-outline` placeholders next to the existing `%btn-base` — a pure refactor, the classes just extend the placeholders now.

## Targeting

The feed can show several posts by the same author, so `id="follow_user_N"` would have been duplicated. The `button_to` form now carries `data-follow-user-id`, and the Turbo Stream uses `replace_all "[data-follow-user-id='…']"` — every control for that author flips in one action, whether it's the profile pill, a feed row, or the modal header.

## Real-time sync

Whether *I* follow an author is my own state, so it never rides the author's public `[user, :follows]` stream (which keeps carrying only the follower/following counts). Each signed-in page subscribes to a private signed stream keyed on the follower, `[current_user, :follow_state]`, and the new `Follows::BroadcastButton` pushes the re-rendered control there on follow/unfollow. Follow in one tab, and the button flips in every other tab of yours; a different viewer's page is untouched.

The button broadcast is synchronous rather than `_later_`: `Follows::Create` / `Follows::Destroy` each know the resulting state, so an inline render can't be reordered, whereas two queued jobs racing through Sidekiq could land a stale label on a rapid toggle. The counts keep using the existing `_later_` jobs.

## Query and cache behaviour

`HomeController#index` preloads the followed-author ids in one query, mirroring the existing `@user_reactions` pattern — the `assert_queries_count` guard moved 9 → 10 and still holds regardless of post count. The header moved out of the `cache post` block, since follow state is per-viewer and must not be fragment-cached.

The non-Turbo path now `redirect_back`s instead of jumping to the author's profile, so a no-JS follow from the feed stays on the feed.
